### PR TITLE
Improve performance and fix bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assrs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Approximate string search"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,9 @@ classifiers = [
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+
+[tool.pylint.main]
+extension-pkg-whitelist = ["assrs"]
+
+[tool.pylint.reports]
+output-format = "colorized"

--- a/src/bktree.rs
+++ b/src/bktree.rs
@@ -7,7 +7,7 @@ use crate::levenshtein;
 
 struct Tree {
     value: String,
-    children: HashMap<usize, Tree>,
+    children: HashMap<u32, Tree>,
 }
 
 impl Tree {
@@ -80,13 +80,13 @@ impl BKTree {
     }
 
     /// Find best match in BK-tree for query
-    pub fn find_one(&self, query: &str, max_edits: Option<usize>) -> Option<(&str, usize)> {
+    pub fn find_one(&self, query: &str, max_edits: Option<u32>) -> Option<(&str, u32)> {
         let tree = self.tree.as_ref()?;
         let mut candidates = VecDeque::new();
         candidates.push_back(tree);
 
         let mut best = None;
-        let mut max_edits = max_edits.unwrap_or(usize::MAX);
+        let mut max_edits = max_edits.unwrap_or(u32::MAX);
 
         while let Some(node) = candidates.pop_front() {
             let distance = levenshtein::levenshtein(query, &node.value);

--- a/src/bktree.rs
+++ b/src/bktree.rs
@@ -43,12 +43,13 @@ impl Tree {
             let distance = levenshtein::levenshtein(query, &node.value);
             if distance <= max_edits {
                 best = Some((node.value.as_str(), distance));
+                if distance == 0 {
+                    return best;
+                }
                 max_edits = distance - 1;
             };
-            let lower = distance - max_edits;
-            let upper = distance + max_edits;
             for (d, subtree) in node.children.iter() {
-                if lower < *d && *d < upper {
+                if d.abs_diff(distance) <= max_edits {
                     stack.push(subtree);
                 }
             }

--- a/src/bktree.rs
+++ b/src/bktree.rs
@@ -5,6 +5,7 @@ use std::iter::once;
 
 use crate::levenshtein;
 
+#[derive(Debug, Default, Clone)]
 struct Tree {
     value: String,
     // Expensive to iterate over HashMap as O(capacity) rather than O(len)
@@ -16,8 +17,7 @@ impl Tree {
     fn new(value: String) -> Self {
         Self {
             value,
-            children_index: HashMap::new(),
-            children: Vec::new(),
+            ..Default::default()
         }
     }
 
@@ -60,6 +60,7 @@ impl Tree {
 
 /// BK-tree storing the strings to search against
 #[pyclass]
+#[derive(Debug, Default, Clone)]
 pub struct BKTree {
     tree: Option<Tree>,
 }
@@ -73,7 +74,7 @@ impl BKTree {
 
     #[staticmethod]
     pub fn new() -> Self {
-        Self { tree: None }
+        Self::default()
     }
 
     pub fn insert(&mut self, value: String) {
@@ -110,12 +111,6 @@ impl BKTree {
     pub fn find_one(&self, query: &str, max_edits: Option<u32>) -> Option<(&str, u32)> {
         let tree = self.tree.as_ref()?;
         tree.find_one(query, max_edits.unwrap_or(u32::MAX))
-    }
-}
-
-impl Default for BKTree {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -6,6 +6,7 @@ pub trait AutomatonState {
     fn can_match(&self, max_edits: u32) -> bool;
 }
 
+#[derive(Debug, Clone)]
 pub struct LevenshteinAutomaton<'a> {
     string: &'a str,
     len: usize,
@@ -13,7 +14,7 @@ pub struct LevenshteinAutomaton<'a> {
     chars: [char; 64],
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum LevenshteinState {
     General(Vec<u32>),
     Bitvector { vp: u64, vn: u64, offset: u32 },
@@ -21,7 +22,7 @@ enum LevenshteinState {
 
 use LevenshteinState::*;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LevenshteinAutomatonState<'a> {
     m: &'a LevenshteinAutomaton<'a>,
     state: LevenshteinState,

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -30,6 +30,10 @@ pub struct LevenshteinAutomatonState<'a> {
 impl<'a> LevenshteinAutomaton<'a> {
     pub fn new(string: &'a str) -> Self {
         let len = string.chars().count();
+        Self::new_assume_len(string, len)
+    }
+
+    fn new_assume_len(string: &'a str, len: usize) -> Self {
         let mut chars = ['\0'; 64];
         for (i, c) in string.chars().take(64).enumerate() {
             chars[i] = c;
@@ -158,12 +162,12 @@ pub fn levenshtein(a: &str, b: &str) -> u32 {
     let len_a = a.chars().count();
     let len_b = b.chars().count();
 
-    let (a, b) = if (len_a < len_b || len_a > 64) && len_b <= 64 {
-        (b, a)
+    let (a, len_a, b) = if (len_a < len_b || len_a > 64) && len_b <= 64 {
+        (b, len_b, a)
     } else {
-        (a, b)
+        (a, len_a, b)
     };
-    let automaton = LevenshteinAutomaton::new(a);
+    let automaton = LevenshteinAutomaton::new_assume_len(a, len_a);
     let mut state = automaton.start();
     for value in b.chars() {
         state.step_mut(value);

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -10,6 +10,7 @@ pub struct LevenshteinAutomaton<'a> {
     string: &'a str,
     len: usize,
     mask: u64,
+    chars: [char; 64],
 }
 
 #[derive(Clone)]
@@ -29,10 +30,15 @@ pub struct LevenshteinAutomatonState<'a> {
 impl<'a> LevenshteinAutomaton<'a> {
     pub fn new(string: &'a str) -> Self {
         let len = string.chars().count();
+        let mut chars = ['\0'; 64];
+        for (i, c) in string.chars().take(64).enumerate() {
+            chars[i] = c;
+        }
         Self {
             string,
             len,
             mask: 1u64.checked_shl(len as u32).unwrap_or(0).wrapping_sub(1),
+            chars,
         }
     }
 
@@ -77,8 +83,8 @@ impl LevenshteinAutomatonState<'_> {
                 // Step 1: D0
                 let mut pm = 0;
                 let mut x = 1u64;
-                for c in self.m.string.chars() {
-                    if c == value {
+                for c in &self.m.chars[..self.m.len] {
+                    if c == &value {
                         pm |= x;
                     }
                     x <<= 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod trie;
 ///
 /// Returns (choice, distance, index) or None (for empty choices)
 #[pyfunction]
-fn levenshtein_extract(query: &str, choices: Vec<&str>) -> Option<(String, usize, usize)> {
+fn levenshtein_extract(query: &str, choices: Vec<&str>) -> Option<(String, u32, usize)> {
     choices
         .iter()
         .map(|x| (x, levenshtein::levenshtein(query, x)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,15 @@ mod trie;
 /// Returns (choice, distance, index) or None (for empty choices)
 #[pyfunction]
 fn levenshtein_extract(query: &str, choices: Vec<&str>) -> Option<(String, u32, usize)> {
-    choices
-        .iter()
-        .map(|x| (x, levenshtein::levenshtein(query, x)))
-        .enumerate()
-        .min_by_key(|(_i, (_x, d))| *d)
-        .map(|(i, (x, d))| (x.to_string(), d, i))
+    let mut best = None;
+    for (i, x) in choices.iter().enumerate() {
+        let distance = levenshtein::levenshtein(query, x);
+        best = Some(best.unwrap_or((distance, i, x)).min((distance, i, x)));
+        if distance == 0 {
+            break;
+        }
+    }
+    best.map(|x| (x.2.to_string(), x.0, x.1))
 }
 
 /// Approximate string searching

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -13,7 +13,7 @@ struct FindResult<'a> {
 pub struct Trie {
     // Indicates terminal and nice when traversing
     value: Option<String>,
-    // Maybe expensive to iterate over O(capacity) rather than O(len)?
+    // Expensive to iterate over HashMap as O(capacity) rather than O(len)
     children_index: HashMap<char, usize>,
     children: Vec<(char, Trie)>,
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -5,7 +5,7 @@ use crate::levenshtein::{AutomatonState, LevenshteinAutomaton};
 
 struct FindResult<'a> {
     value: &'a str,
-    distance: usize,
+    distance: u32,
 }
 
 /// Trie storing the strings to search against
@@ -64,9 +64,9 @@ impl Trie {
     }
 
     /// Find best match in trie for query
-    pub fn find_one(&self, query: &str, max_edits: Option<usize>) -> Option<(&str, usize)> {
+    pub fn find_one(&self, query: &str, max_edits: Option<u32>) -> Option<(&str, u32)> {
         let automaton = LevenshteinAutomaton::new(query);
-        let result = self.find_automaton(&automaton.start(), max_edits.unwrap_or(usize::MAX))?;
+        let result = self.find_automaton(&automaton.start(), max_edits.unwrap_or(u32::MAX))?;
         Some((result.value, result.distance))
     }
 }
@@ -112,7 +112,7 @@ impl Trie {
         )
     }
 
-    fn find_automaton(&self, state: &impl AutomatonState, max_edits: usize) -> Option<FindResult> {
+    fn find_automaton(&self, state: &impl AutomatonState, max_edits: u32) -> Option<FindResult> {
         if !state.can_match(max_edits) {
             return None;
         }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -5,6 +5,7 @@ use crate::levenshtein::{AutomatonState, LevenshteinAutomaton};
 
 /// Trie storing the strings to search against
 #[pyclass]
+#[derive(Debug, Default, Clone)]
 pub struct Trie {
     // Indicates terminal and nice when traversing
     value: Option<String>,
@@ -22,11 +23,7 @@ impl Trie {
 
     #[staticmethod]
     pub fn new() -> Self {
-        Self {
-            value: None,
-            children_index: HashMap::new(),
-            children: Vec::new(),
-        }
+        Self::default()
     }
 
     pub fn insert(&mut self, value: String) {
@@ -62,12 +59,6 @@ impl Trie {
     pub fn find_one(&self, query: &str, max_edits: Option<u32>) -> Option<(&str, u32)> {
         let automaton = LevenshteinAutomaton::new(query);
         self.find_automaton(&automaton.start(), max_edits.unwrap_or(u32::MAX))
-    }
-}
-
-impl Default for Trie {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,82 @@
+# pylint: disable=invalid-name,missing-docstring
+
+import random
+import string
+import time
+import timeit
+
+import rapidfuzz
+
+import assrs
+
+NUMBER = 1
+
+
+def timer(func, samples, *args, number=NUMBER, repeat=3, name=None, **kwargs):
+    if name is None:
+        name = repr(func)
+
+    def wrapped():
+        for x in samples:
+            func(x, *args, **kwargs)
+
+    times = timeit.repeat(wrapped, number=number, repeat=repeat)
+    print(f"{name:8s} {min(times)/len(samples)*1000:.2f}ms")
+
+
+def run(choices, samples):
+    print(len(choices), len(samples))
+
+    tr = assrs.Trie(choices)
+    timer(tr.find_one, samples)
+    timer(tr.find_one, samples, 3)
+
+    t = assrs.BKTree(choices)
+    timer(t.find_one, samples)
+    timer(t.find_one, samples, 3)
+
+    timer(assrs.levenshtein_extract, samples, choices, number=1)
+    timer(
+        lambda x: min(choices, key=lambda s: assrs.levenshtein(x, s)),
+        samples,
+        number=1,
+        name="assrs.levenshtein",
+    )
+    timer(
+        rapidfuzz.process.extractOne,
+        samples,
+        choices,
+        scorer=rapidfuzz.distance.Levenshtein.distance,
+    )
+    timer(
+        lambda x: min(
+            choices, key=lambda s: rapidfuzz.distance.Levenshtein.distance(x, s)
+        ),
+        samples,
+        number=1,
+        name="rapidfuzz.distance.Levenshtein",
+    )
+
+    print()
+
+
+def random_words(n, length=10):
+    return [
+        "".join(
+            random.choice(string.ascii_letters + string.digits) for _ in range(length)
+        )
+        for _ in range(n)
+    ]
+
+
+def main():
+    with open("/usr/share/dict/words", encoding="utf-8") as f:
+        words = [l.strip() for l in f]
+
+    time.sleep(1)
+    run(random_words(100_000), random_words(100))
+    run(words, words[::1000])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Performance improvements:
- Use `Vec` to store children in trees for faster iteration (`HashMap` for insertion and search)
- Use `u32` for distances to avoid casting
- Slightly faster `can_match` using integer addition
- Create `char` array in automaton to avoid repeated iteration over characters
- Avoid counting string characters more than once
- Use `Vec` instead of `VecDeque` for `BKTree` exploration stack
- Refactor `Trie` and `BKTree` exploration methods
- Refactor Levenshtein automaton state to `enum`
- Break extract loop if exact match found

Bug fixes:
- Fix integer overflow bugs when distance is 0
